### PR TITLE
Allow user to specify colormap vmin and vmax

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: cptextras
-  version: "1.1.0"
+  version: "1.2.0"
 
 source:
   path: ..

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(Path(__file__ ).parent / 'README.md', 'r', encoding='utf-8') as fh:
 
 setup(
     name="cptextras",
-    version="1.1.0",
+    version="1.2.0",
     author="Kyle Hall",
     author_email="pycpt-help@iri.columbia.edu",
     description=(

--- a/src/cptextras/__init__.py
+++ b/src/cptextras/__init__.py
@@ -6,6 +6,6 @@ from .extrafuncs import *
 from .dlcolors import *
 from .configuration import load_configuration, save_configuration
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 __author__ = "Kyle Hall"
 __license__ = "MIT"

--- a/src/cptextras/dlcolors.py
+++ b/src/cptextras/dlcolors.py
@@ -34,7 +34,7 @@ def colormap_info():
     ret = "Colormaps starting with 'cpt.' come from\nthe International Research Institute\nfor Climate & Society's Climate Predictability Tool\n\nColormaps starting with 'pycpt.' come from PyCPT.\n\nColormaps starting with 'cmc.' come\nfrom cmcrameri, all credit to Fabio Crameri\nsee their message:\n\n" + cmc.__doc__ + '\nAll other colormaps come from matplotlib\nPlease Cite Colormaps accordingly!'
     print(ret)
 #if user_color != None:
-def prepare_canvas(tailoring=None,predictand='PRCP',type=None,user_color=None):
+def prepare_canvas(tailoring=None,predictand='PRCP',type=None,user_color=None, user_vmin=None, user_vmax=None):
     if tailoring != None and (type==None or type=='deterministic'):
         if tailoring == 'Anomaly' :
             if 'PRCP' in predictand:
@@ -82,8 +82,12 @@ def prepare_canvas(tailoring=None,predictand='PRCP',type=None,user_color=None):
                 mark='black'
                 barcolor=cmaps['DL_TEMP_POE_COLORMAP']
 
-            if not user_color == None:
+            if not user_color is None:
                 barcolor=cmaps[user_color]
+            if not user_vmin is None:
+                vmin = user_vmin
+            if not user_vmax is None:
+                vmax = user_vmax
             return for_title, vmin, vmax, mark, barcolor
         else:
             for_title='('+tailoring+')'
@@ -92,8 +96,12 @@ def prepare_canvas(tailoring=None,predictand='PRCP',type=None,user_color=None):
                 vmax=None
                 barcolor=cmaps['DL_RAINFALL_COLORMAP']
 
-        if not user_color == None:
+        if not user_color is None:
             barcolor=cmaps[user_color]
+        if not user_vmin is None:
+            vmin = user_vmin
+        if not user_vmax is None:
+            vmax = user_vmax
         return for_title, vmin, vmax, barcolor
 
     elif type=='probabilistic' :
@@ -117,8 +125,12 @@ def prepare_canvas(tailoring=None,predictand='PRCP',type=None,user_color=None):
             vmax=40
             barcolor=cmaps['DL_TEMP_COLORS']
 
-        if not user_color == None:
+        if not user_color is None:
             barcolor=cmaps[user_color]
+        if not user_vmin is None:
+            vmin = user_vmin
+        if not user_vmax is None:
+            vmax = user_vmax
         return for_title, vmin, vmax, barcolor
 
 #


### PR DESCRIPTION
Anomalies should be displayed using a symmetric, divergent colormap. It should be possible to make that choice automatically, but that's more work than I can take on right now, so I'm just making it possible to specify the colormap range explicitly in the notebook.